### PR TITLE
Test improvement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ vendor/
 composer.lock
 tests/Unit/Data/*
 !**/.gitkeep
+*.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,15 @@
 language: php
-dist: trusty
 php:
-  - '7.0'
   - '7.1'
   - '7.2'
+  - '7.3'
+  - '7.4'
   - nightly
-  - 'hhvm'
 matrix:
   allow_failures:
     - php: nightly
 install:
-  - composer update
+  - composer install
 script:
  - ./vendor/bin/phpunit --coverage-clover ./tests/Logs/clover.xml
 after_script:

--- a/composer.json
+++ b/composer.json
@@ -10,11 +10,13 @@
         }
     ],
     "require": {
-        "php": "^7.0"
+        "php": ">=7.1",
+        "ext-zlib": "*",
+        "ext-json": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.5",
-        "satooshi/php-coveralls": "^2.0"
+        "phpunit/phpunit": "^7.0 || ^8.0",
+        "php-coveralls/php-coveralls": "^2.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/JsonKeyValueStore.php
+++ b/src/JsonKeyValueStore.php
@@ -61,7 +61,7 @@ class JsonKeyValueStore
         $this->content = json_decode(gzdecode($rawContent));
 
         if ($this->content === null) {
-            throw new Exception('Invalid store content');
+            throw new \Exception('Invalid store content');
         }
     }
 

--- a/tests/Unit/BasicUsageTest.php
+++ b/tests/Unit/BasicUsageTest.php
@@ -41,7 +41,7 @@ final class BasicUsageTest extends TestCase
     {
         $store = $this->createNewStore();
 
-        $this->assertTrue(file_exists($store->getFile()));
+        $this->assertFileExists($store->getFile());
         $this->assertEquals('{}', gzdecode(file_get_contents($store->getFile())));
     }
 
@@ -85,7 +85,7 @@ final class BasicUsageTest extends TestCase
 
         $value = $store->get('testString');
 
-        $this->assertTrue(is_string($value));
+        $this->assertIsString($value);
         $this->assertEquals('stringValue', $value);
     }
 
@@ -95,7 +95,7 @@ final class BasicUsageTest extends TestCase
 
         $value = $store->get('testInteger');
 
-        $this->assertTrue(is_int($value));
+        $this->assertIsInt($value);
         $this->assertEquals(12345, $value);
     }
 
@@ -112,7 +112,7 @@ final class BasicUsageTest extends TestCase
         $testObj->pet->type = 'cat';
         $testObj->pet->name = 'Destructor';
 
-        $this->assertTrue(is_object($value));
+        $this->assertIsObject($value);
         $this->assertEquals($testObj, $value);
     }
 


### PR DESCRIPTION
# Changed log
- Since the `php-7.0` will be unsupported and let this package require `php-7.1` version at least.
- The `composer.lock` is not existed on Git version control, and using the `composer install` command.
- Using the PHPUnit `^7.0` and `^8.0` versions to support different `php-7.x` versions.
- Add `*.cache` on `.gitignore` file to ignore file `.phpunit.result.cache` on Git version control.
- The `satooshi/php-coveralls` package is deprecated. Using the `php-coveralls/php-coveralls` instead.
- Using the `assertFileExists` to assert given file path should be existed.
- Using the `assertIsInt` to assert variable type should be `integer`.
- Using the `assertIsObject` to assert variable type should be `object`.
- Using the `assertIsString` to assert variable type should be `string`.