### PR TITLE
Remove StyleCI

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![Build Status](https://travis-ci.org/Jord-JD/json-key-value-store.svg?branch=master)](https://travis-ci.org/Jord-JD/json-key-value-store)
 [![Coverage Status](https://coveralls.io/repos/github/Jord-JD/json-key-value-store/badge.svg?branch=master)](https://coveralls.io/github/Jord-JD/json-key-value-store?branch=master)
-[![StyleCI](https://styleci.io/repos/132195531/shield?branch=master)](https://styleci.io/repos/132195531)
 
 A simple JSON based key value store.
 


### PR DESCRIPTION
Removes the obsolete StyleCI badge. StyleCI is no longer part of the maintenance workflow.